### PR TITLE
GPII-2081: Use the dynamic device reporter by default

### DIFF
--- a/staging/start.cmd
+++ b/staging/start.cmd
@@ -1,4 +1,4 @@
 echo off
-
+set NODE_ENV=gpii.config.all.development.dr.production
 cd windows
 start /min ..\node.exe gpii.js


### PR DESCRIPTION
https://issues.gpii.net/browse/GPII-2081

After installing the resulting installer, you can test it in the following the way:
* Start the GPII and check the output from the device reporter (in a browser go to http://localhost:8081/device). NVDA (org.nvda-project) shouldn't be listed as installed.
* Install NVDA (i.e.: choco install nvda -y) - After the NVDA installation is finished, check the output from the device reporter again. This time NVDA should be reported as installed.

