### PR TITLE
GPII-2571: GPII should start automatically when the system reboot

### DIFF
--- a/setup/Product.wxs
+++ b/setup/Product.wxs
@@ -31,8 +31,8 @@
     <Property Admin="yes" Id="GPII_SHORTCUTS" Value="1" />
     <Property Admin="yes" Id="GPII_DESKTOP_SHORTCUTS" Value="1" />
     <Property Admin="yes" Id="GPII_START_MENU_SHORTCUTS" Value="1" />
-    <Property Admin="yes" Id="GPII_AUTOSTART" Value="0" />
-    <Property Admin="yes" Id="GPII_START_AFTER_INSTALLATION" Value="0" />
+    <Property Admin="yes" Id="GPII_AUTOSTART" Value="1" />
+    <Property Admin="yes" Id="GPII_START_AFTER_INSTALLATION" Value="1" />
 
     <Property Admin="yes" Id="USB_LISTENER_SHORTCUTS" Value="1" />
     <Property Admin="yes" Id="USB_LISTENER_DESKTOP_SHORTCUTS" Value="0" />


### PR DESCRIPTION
After installation GPII should start automatically and after every reboot.