### PR TITLE
GPII-2554: Tray icon fix.

### DIFF
--- a/setup/trayicon.cs
+++ b/setup/trayicon.cs
@@ -146,23 +146,17 @@ namespace TrayIconApplication
                         NOTIFYITEM_OUT itemOut = new NOTIFYITEM_OUT(item);
                         uint newValue = (bool)alwaysShow ? NOTIFYITEM.AlwaysShow : NOTIFYITEM.Hide;
                         found = true;
-                        if (true || itemOut.dwUserPref != newValue)
-                        {
-                            Console.WriteLine("Updating {0}", item.pszExeName);
-                            itemOut.dwUserPref = newValue;
 
-                            if (TrayIcon.UseNew)
-                            {
-                                ((ITrayNotifyNew)trayNotify).SetPreference(itemOut);
-                            }
-                            else
-                            {
-                                ((ITrayNotifyOld)trayNotify).SetPreference(itemOut);
-                            }
+                        Console.WriteLine("Updating {0}", item.pszExeName);
+                        itemOut.dwUserPref = newValue;
+
+                        if (TrayIcon.UseNew)
+                        {
+                            ((ITrayNotifyNew)trayNotify).SetPreference(itemOut);
                         }
                         else
                         {
-                            Console.WriteLine("No need to update {0}", item.pszExeName);
+                            ((ITrayNotifyOld)trayNotify).SetPreference(itemOut);
                         }
                     }
                 });


### PR DESCRIPTION
When re-installing, the tray icon doesn't get locked.

With this fix, it waits until gpii-app has started before configures the icon..