### PR TITLE
GPII-3218: Fixed the installer build to work with the latest (4.0.15.0) version of msbuild.extensionpack

### DIFF
--- a/setup/setup.msbuild
+++ b/setup/setup.msbuild
@@ -4,7 +4,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
          >
 
-  <Import Project="C:\Program Files (x86)\MSBuild\ExtensionPack\4.0\MSBuild.ExtensionPack.tasks"/>
+  <Import Project="C:\Program Files (x86)\MSBuildExtensionPack\4.0\MSBuild.ExtensionPack.tasks"/>
 
   <PropertyGroup>
     <SourceDir>..\staging</SourceDir>


### PR DESCRIPTION
gpii-windows doesn't build without either this, or https://github.com/GPII/windows/pull/179 (GPII-3092: Removed installer)