### PR TITLE
GPII-3203: Added a custom action to kill morphic-app.exe before install/uninstall

### DIFF
--- a/setup/Product.wxs
+++ b/setup/Product.wxs
@@ -168,9 +168,11 @@
     <!-- We use asyncNoWait in order to not wait for their return codes -->
     <CustomAction Id="RunGPII" ExeCommand="[INSTALLFOLDER]\start.cmd" Directory="INSTALLFOLDER" Return="asyncNoWait" />
     <CustomAction Id="RunTrayIcon" ExeCommand="[INSTALLFOLDER]\windows\trayicon.exe morphic-app.exe -show" Directory="INSTALLFOLDER" Return="asyncNoWait" />
+    <CustomAction Id="KillApp" Directory="INSTALLFOLDER" Return="ignore" ExeCommand="&quot;[SystemFolder]taskkill.exe&quot; /F /IM &quot;morphic-app.exe&quot;" />
 
     <!-- Install execute sequence of custom actions -->
     <InstallExecuteSequence>
+      <Custom Action="KillApp" Before="InstallValidate" />
       <Custom Action="RunGPII" After="InstallFinalize">
         GPII_START_AFTER_INSTALLATION="1"
       </Custom>


### PR DESCRIPTION
- When uninstalling, the GPII stops without any problem
- When installing a new version on top of a previous one, it stops the GPII at the beginning and it starts again when the installation is done
