### PR TITLE
GPII-3928: Renamed black on yellow high contrast theme

### DIFF
--- a/themes/blackOnYellow.theme
+++ b/themes/blackOnYellow.theme
@@ -2,7 +2,7 @@
 
 [Theme]
 ; High Contrast White - IDS_THEME_DISPLAYNAME_HCWHITE
-DisplayName=Yellow on Black
+DisplayName=Black on Yellow
 ThemeId={CEE5AC41-6C74-4963-B6AA-D4061201684E}
 
 ; Computer - SHIDI_SERVER


### PR DESCRIPTION
Fixes https://issues.gpii.net/browse/GPII-3928 according to https://github.com/GPII/universal/pull/763 (already merged into universal/master) as https://github.com/GPII/universal/commit/c0423a68d879faf102ca353e1c74a20317ec67ff