### PR TITLE
GPII-4088 Pointing start.cmd to staging

### DIFF
--- a/staging/start.cmd
+++ b/staging/start.cmd
@@ -1,4 +1,4 @@
 @echo off
-set GPII_CLOUD_URL=https://flowmanager.prd.gcp.gpii.net
+set GPII_CLOUD_URL=https://flowmanager.stg.gcp.gpii.net
 cd windows
 start /min morphic-app.exe


### PR DESCRIPTION
https://issues.gpii.net/browse/GPII-4088

We may want to handle this a different way, but somehow it seems that the installer built from a regular checkout of gpii-app should point to stage.