### PR TITLE
SW-13: Updated UIO+ for Morphic chrome extension ID

### DIFF
--- a/setup/Product.wxs
+++ b/setup/Product.wxs
@@ -162,7 +162,7 @@
           <!-- This registry key forces the installation of UIO+ -->
           <RegistryValue Name="1"
                          Type="string"
-                         Value="okenndailhmikjjfcnmolpaefecbpaek;https://clients2.google.com/service/update2/crx"
+                         Value="bichakaigmeiojnhfjnbijocdloigmeg;https://clients2.google.com/service/update2/crx"
                          KeyPath="yes"/>
         </RegistryKey>
       </Component>


### PR DESCRIPTION
This new ID corresponds to the chrome extension that is able to
communicate with Morphic. This is:
https://github.com/GPII/gpii-chrome-extension